### PR TITLE
Add activation to enforce non-negative LSTM predictions

### DIFF
--- a/train_lstm.py
+++ b/train_lstm.py
@@ -179,9 +179,11 @@ class LSTMModel(nn.Module):
         super(LSTMModel, self).__init__()
         self.lstm = nn.LSTM(input_size, hidden_size, num_layers, batch_first=True, dropout=0.2)
         self.fc = nn.Linear(hidden_size, 1)
+        self.activation = nn.ReLU()
     def forward(self, x):
         out, _ = self.lstm(x)
         out = self.fc(out[:, -1, :])
+        out = self.activation(out)
         return out
 
 model = LSTMModel(input_size=len(features), hidden_size=HIDDEN_SIZE, num_layers=NUM_LAYERS).to(DEVICE)


### PR DESCRIPTION
## Summary
- ensure LSTM outputs are non-negative by adding ReLU activation after final linear layer

## Testing
- ⚠️ `python train_lstm.py` *(missing pandas; package installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1dc5d850832e9823ec4cfc8e4d41