### PR TITLE
Use LeakyReLU activation in LSTMModel

### DIFF
--- a/train_lstm.py
+++ b/train_lstm.py
@@ -221,7 +221,7 @@ class LSTMModel(nn.Module):
         super(LSTMModel, self).__init__()
         self.lstm = nn.LSTM(input_size, hidden_size, num_layers, batch_first=True, dropout=0.2)
         self.fc = nn.Linear(hidden_size, output_size)
-        self.activation = nn.ReLU()
+        self.activation = nn.LeakyReLU()
 
     def forward(self, x):
         out, _ = self.lstm(x)


### PR DESCRIPTION
## Summary
- Replace `nn.ReLU` with `nn.LeakyReLU` in `LSTMModel` to allow gradients on negative outputs

## Testing
- `python train_lstm.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas numpy scikit-learn torch tqdm` *(fails: Could not find a version that satisfies the requirement pandas; proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2f98f634832ebe29d33a2f55ed33