### PR TITLE
Add epsilon to SMAPE denominator

### DIFF
--- a/train_xgboost.py
+++ b/train_xgboost.py
@@ -8,13 +8,13 @@ import os
 print("XGBoost-based demand forecasting script with correlation features started.")
 
 # --- SMAPE 평가 지표 함수 정의 ---
-def smape(y_true, y_pred):
+def smape(y_true, y_pred, eps: float = 1e-8):
+    """SMAPE metric with a small epsilon in the denominator to avoid ``0/0``."""
     y_true = np.array(y_true)
     y_pred = np.array(y_pred)
     numerator = np.abs(y_pred - y_true)
-    denominator = (np.abs(y_true) + np.abs(y_pred)) / 2
-    ratio = np.where(denominator == 0, 0, numerator / denominator)
-    return np.mean(ratio) * 100
+    denominator = (np.abs(y_true) + np.abs(y_pred)) / 2 + eps
+    return np.mean(numerator / denominator) * 100
 
 # --- 1. 데이터 로딩 ---
 print("Step 1: Loading data...")


### PR DESCRIPTION
## Summary
- Stabilize `smape` metric by adding small epsilon to its denominator.
- Update `SMAPELoss` to use the same epsilon-adjusted denominator.
- Apply the same epsilon logic in XGBoost training script.

## Testing
- `python train_xgboost.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas xgboost scikit-learn` *(fails: Cannot connect to proxy)*
- `python -m py_compile train_lstm.py train_xgboost.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab3b9af03c832ebe29a32bbc33988c