### PR TITLE
Handle grouped test data for future predictions

### DIFF
--- a/train_lstm.py
+++ b/train_lstm.py
@@ -90,35 +90,38 @@ def get_future_date_str(date_str, days_to_add):
 # --- 1. 데이터 로딩 및 피처 엔지니어링 ---
 print("Step 1: Loading and feature engineering...")
 train_df = pd.read_csv('train/train.csv')
-test_files = glob.glob('test/*.csv')
+test_files = glob.glob('test/TEST_*.csv')
 test_df_list = []
 for file in test_files:
     temp_df = pd.read_csv(file)
     test_id = os.path.splitext(os.path.basename(file))[0]
-    # 날짜 정렬 후 마지막 7행만 미래 예측 대상으로 처리
-    temp_df = temp_df.sort_values('영업일자')
     temp_df['영업일자'] = pd.to_datetime(temp_df['영업일자'])
 
-    past_df = temp_df.iloc[:-7].copy()
-    past_df['submission_date'] = past_df['영업일자'].dt.strftime('%Y-%m-%d')
-
-    future_df = temp_df.tail(7).copy().reset_index(drop=True)
-    future_df['submission_date'] = [f"{test_id}+{i+1}일" for i in range(len(future_df))]
-    future_df['매출수량'] = np.nan
-
-    temp_df = pd.concat([past_df, future_df], ignore_index=True)
-    temp_df['test_id'] = test_id
-    test_df_list.append(temp_df)
+    for _, g in temp_df.groupby('영업장명_메뉴명'):
+        g = g.sort_values('영업일자')
+        past = g.iloc[:-7].copy()
+        past['submission_date'] = past['영업일자'].dt.strftime('%Y-%m-%d')
+        future = g.tail(7).copy().reset_index(drop=True)
+        future['submission_date'] = [f"{test_id}+{i+1}일" for i in range(len(future))]
+        future['매출수량'] = np.nan
+        past['test_id'] = test_id
+        future['test_id'] = test_id
+        test_df_list.append(pd.concat([past, future], ignore_index=True))
 
 test_df = pd.concat(test_df_list, ignore_index=True)
 
 # submission_date <-> 실제 날짜 매핑 생성
 submission_date_map = test_df.set_index(test_df['영업일자'].astype(str))['submission_date'].to_dict()
 submission_to_date_map = test_df.set_index('submission_date')['영업일자'].astype(str).to_dict()
-expected_test_nans = 7 * len(test_files)
+expected_test_nans = 7 * test_df['영업장명_메뉴명'].nunique()
 actual_test_nans = test_df['매출수량'].isna().sum()
 if actual_test_nans != expected_test_nans:
     raise ValueError(f"Unexpected number of NaNs in test data: {actual_test_nans} (expected {expected_test_nans})")
+
+nans_per_item = test_df[test_df['매출수량'].isna()].groupby('영업장명_메뉴명').size()
+if not (nans_per_item == 7).all():
+    raise ValueError("Not all item-date combinations were generated in test data.")
+
 sample_submission_df = pd.read_csv('sample_submission.csv')
 
 def create_features_train(df):


### PR DESCRIPTION
## Summary
- Load TEST files by item group, splitting past and future rows
- Assign submission date IDs and NaN targets for future predictions
- Validate expected NaNs and item/date coverage before pipeline

## Testing
- `python -m py_compile train_lstm.py train_xgboost.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab4988c050832ead4ffb48490fc8d9