### PR TITLE
Wrap features with numpy array before tensor conversion

### DIFF
--- a/train_lstm.py
+++ b/train_lstm.py
@@ -442,7 +442,7 @@ with torch.no_grad():
                 predicted_seq = np.repeat(init_val, len(current_dates))
             else:
                 input_features = sequence_data[features].values
-                input_tensor = torch.tensor([input_features], dtype=torch.float32).to(DEVICE)
+                input_tensor = torch.tensor(np.array([input_features]), dtype=torch.float32).to(DEVICE)
                 prediction_scaled = model(input_tensor).cpu().numpy()[0]
                 predicted_seq = prediction_scaled[:len(current_dates)]
             batch_predictions[item_id] = predicted_seq


### PR DESCRIPTION
## Summary
- wrap `input_features` in a NumPy array before converting to a tensor in the prediction loop to ensure correct shape handling

## Testing
- `python -m py_compile train_lstm.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab4989c5e0832e9478b39a18d11e5c