### PR TITLE
Add sample weighting to LSTM training

### DIFF
--- a/train_lstm_optuna.py
+++ b/train_lstm_optuna.py
@@ -33,6 +33,7 @@ best_smape = float("inf")
     submission_date_map,
     submission_to_date_map,
     test_indices,
+    item_weights,
 ) = prepare_datasets(SEQUENCE_LENGTH, PREDICT_LENGTH, BATCH_SIZE)
 
 


### PR DESCRIPTION
## Summary
- support sample-wise weights in SMAPE loss and return item weights from dataset preparation
- apply item-based weights during LSTM training and validation loops

## Testing
- `python -m py_compile lstm_utils.py train_lstm.py train_lstm_optuna.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab7346aaec832eb489bc26cc7c5ee6