### PR TITLE
Add time-step weighting to SMAPE loss and LSTM training

### DIFF
--- a/lstm_utils.py
+++ b/lstm_utils.py
@@ -39,12 +39,15 @@ class SMAPELoss(nn.Module):
         y_pred: torch.Tensor,
         y_true: torch.Tensor,
         weights: torch.Tensor | None = None,
+        time_weights: torch.Tensor | None = None,
     ) -> torch.Tensor:
         numerator = torch.abs(y_pred - y_true)
         denominator = (torch.abs(y_true) + torch.abs(y_pred)) / 2 + self.eps
         loss = numerator / denominator
         if weights is not None:
             loss = loss * weights
+        if time_weights is not None:
+            loss = loss * time_weights
         if self.reduction == "none":
             return loss
         if self.reduction == "sum":


### PR DESCRIPTION
## Summary
- allow SMAPELoss to accept optional `time_weights` for per-step weighting
- apply time-based weighting vector in `train_lstm.py` when computing L1 and SMAPE losses

## Testing
- `python -m py_compile lstm_utils.py train_lstm.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab90d3c828832eb71887e33a3c816b