### PR TITLE
Refactor dataset preparation to isolate test data

### DIFF
--- a/train_lstm.py
+++ b/train_lstm.py
@@ -119,6 +119,10 @@ def main():
         num_items,
     ) = prepare_datasets(SEQUENCE_LENGTH, curriculum_lengths[0], BATCH_SIZE)
 
+    assert (
+        combined_df.loc[combined_df['매출수량'].notna(), 'source'] == 'train'
+    ).all(), "Non-train data detected in training set"
+
     if cnn_channels is None:
         cnn_channels = len(features) + store_emb_dim + item_emb_dim
 
@@ -167,6 +171,9 @@ def main():
                 num_stores,
                 num_items,
             ) = prepare_datasets(SEQUENCE_LENGTH, curr_len, BATCH_SIZE)
+            assert (
+                combined_df.loc[combined_df['매출수량'].notna(), 'source'] == 'train'
+            ).all(), "Non-train data detected in training set"
         for param_group in optimizer.param_groups:
             param_group["lr"] = LEARNING_RATE / 25
         warmup_epochs = min(2, epochs)


### PR DESCRIPTION
## Summary
- Move test data handling into `load_and_prepare_test_data` helper
- Ensure training sequences use only rows where `source == 'train'`
- Add assertions in training script verifying evaluation data isn't used

## Testing
- `python -m py_compile lstm_utils.py train_lstm.py`
- `pip install -q numpy pandas scikit-learn holidays tqdm torch` *(failed: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68ab94169070832e8c1fdbefca33b79f